### PR TITLE
feat: enable parallel test execution for backend tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,10 +243,11 @@ Note:
 
 ### Backend Testing
 - **Framework**: Pytest with fixtures
+- **Parallel Execution**: pytest-xdist with auto-detection (`-n auto`) and worksteal distribution
 - **Coverage**: 90% threshold enforced
 - **Database**: PostgreSQL via testcontainers (requires Docker)
 - **Test Isolation**: TRUNCATE CASCADE before/after each test
-- **Structure**: 
+- **Structure**:
   - `tests/unit/` - Function and class tests
   - `tests/integration/` - API endpoint tests
 - **Key Fixtures**:

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ test-backend-types: ## Run mypy type checking
 
 .PHONY: test-backend-pytest
 test-backend-pytest: ## Run pytest with coverage
-	@echo "$(BLUE)Running backend tests with coverage...$(NC)"
-	cd backend && uv run pytest -v --cov=app --cov-report=xml --cov-report=term
+	@echo "$(BLUE)Running backend tests with coverage (parallel execution)...$(NC)"
+	cd backend && uv run pytest -v -n auto --dist worksteal --cov=app --cov-report=xml --cov-report=term
 	@echo "$(GREEN)✓ Backend tests passed$(NC)"
 
 .PHONY: test-backend-all


### PR DESCRIPTION
- Updated Makefile to include pytest-xdist flags (-n auto --dist worksteal)
- Tests now run in parallel using automatic CPU core detection
- Worksteal distribution ensures efficient load balancing across workers
- Updated CLAUDE.md documentation to reflect parallel execution capability

This change improves test execution speed by leveraging multiple CPU cores. The existing pytest-xdist dependency and configuration in pyproject.toml are now properly utilized during test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)