### PR TITLE
fix: install dependencies before running tests in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Install dependencies
+        run: make install-all
+
       - name: Start PostgreSQL
         run: docker compose -f docker-compose.dev.yml up -d
 


### PR DESCRIPTION
Fixes "eslint: not found" error in test job by adding dependency installation step before running tests.

Issue:
- Test job was setting up Node.js and Python environments
- But never ran npm install or uv sync to install dependencies
- make test-all requires dependencies to be installed first
- Result: "sh: 1: eslint: not found" error

Solution:
- Added "Install dependencies" step using make install-all
- Runs after environment setup but before starting PostgreSQL
- make install-all installs both UI (npm) and backend (uv) dependencies

Workflow Steps (corrected order):
1. Checkout code
2. Set up Node.js (with npm cache)
3. Set up Python
4. Install uv
5. Install dependencies (NEW - make install-all)
6. Start PostgreSQL
7. Run all tests
8. Stop PostgreSQL

This ensures all dependencies are available before running the test suite.