### PR TITLE
feat: migrate FastAPI backend to async SQLAlchemy 2.0 with AsyncSession

### DIFF
--- a/backend/app/database/database.py
+++ b/backend/app/database/database.py
@@ -28,8 +28,13 @@ ASYNC_DATABASE_URL = SQLALCHEMY_DATABASE_URL.replace("postgresql://", "postgresq
     "postgresql+psycopg2://", "postgresql+asyncpg://"
 )
 
-# Create async SQLAlchemy engine for PostgreSQL
-async_engine = create_async_engine(ASYNC_DATABASE_URL, echo=False)
+# Create async SQLAlchemy engine for PostgreSQL with connection pool settings
+async_engine = create_async_engine(
+    ASYNC_DATABASE_URL,
+    echo=False,
+    pool_pre_ping=True,  # Verify connections before use to avoid stale connection errors
+    pool_recycle=3600,  # Recycle connections after 1 hour to prevent stale connections
+)
 
 # Create AsyncSessionLocal class for async database sessions
 AsyncSessionLocal = async_sessionmaker(

--- a/backend/app/database/database.py
+++ b/backend/app/database/database.py
@@ -1,12 +1,13 @@
 """
 SQLAlchemy database configuration for ParchMark backend.
-Configures PostgreSQL database engine and session management.
+Configures PostgreSQL database engine and session management with async support.
 """
 
 import os
 
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Load environment variables from .env file
@@ -22,21 +23,53 @@ if not SQLALCHEMY_DATABASE_URL.startswith(("postgresql://", "postgresql+psycopg2
         "\nPlease set DATABASE_URL to a valid PostgreSQL connection string."
     )
 
-# Create SQLAlchemy engine for PostgreSQL
+# Convert sync URL to async URL for asyncpg
+ASYNC_DATABASE_URL = SQLALCHEMY_DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://").replace(
+    "postgresql+psycopg2://", "postgresql+asyncpg://"
+)
+
+# Create async SQLAlchemy engine for PostgreSQL
+async_engine = create_async_engine(ASYNC_DATABASE_URL, echo=False)
+
+# Create AsyncSessionLocal class for async database sessions
+AsyncSessionLocal = async_sessionmaker(
+    bind=async_engine,
+    class_=AsyncSession,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+)
+
+# Create sync SQLAlchemy engine (kept for backwards compatibility during migration)
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
-# Create SessionLocal class for database sessions
+# Create SessionLocal class for sync database sessions (kept for backwards compatibility)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Create Base class for declarative models
 Base = declarative_base()
 
 
-# Dependency to get database session
+# Async dependency to get database session
+async def get_async_db():
+    """
+    Async dependency function to get database session.
+    Yields an async database session and ensures it's closed after use.
+    """
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+
+# Sync dependency (kept for backwards compatibility during migration)
 def get_db():
     """
     Dependency function to get database session.
     Yields a database session and ensures it's closed after use.
+
+    DEPRECATED: Use get_async_db for new code.
     """
     db = SessionLocal()
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from app.database.database import async_engine
 from app.database.init_db import init_database
 from app.routers import auth, health, notes, settings
 
@@ -48,6 +49,10 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     logger.info("Shutting down ParchMark API...")
+
+    # Dispose async engine to close all connections cleanly
+    await async_engine.dispose()
+    logger.info("Database connections closed")
 
 
 # Create FastAPI application with enhanced configuration

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -4,16 +4,16 @@ Provides comprehensive health status including database connectivity.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.database import get_db
+from app.database.database import get_async_db
 from app.services.health_service import health_service
 
 router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health")
-async def health_check(db: Session = Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_async_db)):
     """
     Comprehensive health check endpoint.
 
@@ -24,6 +24,6 @@ async def health_check(db: Session = Depends(get_db)):
         HTTPException: 503 if service is unhealthy
     """
     try:
-        return health_service.get_health_status(db)
+        return await health_service.get_health_status(db)
     except Exception as e:
         raise HTTPException(status_code=503, detail="Service unhealthy: Database connection failed") from e

--- a/backend/app/services/health_service.py
+++ b/backend/app/services/health_service.py
@@ -2,8 +2,12 @@
 Health check service for monitoring application and database status.
 """
 
+import logging
+
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 
 class HealthService:
@@ -23,7 +27,8 @@ class HealthService:
         try:
             await db.execute(text("SELECT 1"))
             return True
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Database health check failed: {e}")
             return False
 
     @staticmethod

--- a/backend/app/services/health_service.py
+++ b/backend/app/services/health_service.py
@@ -3,36 +3,36 @@ Health check service for monitoring application and database status.
 """
 
 from sqlalchemy import text
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 class HealthService:
     """Service for performing health checks on application components."""
 
     @staticmethod
-    def check_database_connection(db: Session) -> bool:
+    async def check_database_connection(db: AsyncSession) -> bool:
         """
         Check if database connection is working.
 
         Args:
-            db: Database session
+            db: Async database session
 
         Returns:
             bool: True if connection is healthy, False otherwise
         """
         try:
-            db.execute(text("SELECT 1"))
+            await db.execute(text("SELECT 1"))
             return True
         except Exception:
             return False
 
     @staticmethod
-    def get_health_status(db: Session) -> dict:
+    async def get_health_status(db: AsyncSession) -> dict:
         """
         Get comprehensive health status of the application.
 
         Args:
-            db: Database session
+            db: Async database session
 
         Returns:
             dict: Health status including database connectivity
@@ -40,7 +40,7 @@ class HealthService:
         Raises:
             Exception: If database connection fails
         """
-        is_db_healthy = HealthService.check_database_connection(db)
+        is_db_healthy = await HealthService.check_database_connection(db)
 
         if not is_db_healthy:
             raise Exception("Database connection failed")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "uvicorn[standard]==0.24.0",
     "sqlalchemy>=2.0.32",
     "psycopg2-binary>=2.9.7",
+    "asyncpg>=0.29.0",
     "python-jose[cryptography]==3.3.0",
     "passlib[bcrypt]==1.7.4",
     "bcrypt==3.2.0",

--- a/backend/tests/integration/auth/test_auth_router.py
+++ b/backend/tests/integration/auth/test_auth_router.py
@@ -126,10 +126,10 @@ class TestLoginEndpoint:
         data = response.json()
         assert "access_token" in data
 
-    @patch("app.routers.auth.authenticate_user")
-    def test_login_database_error(self, mock_auth, client: TestClient):
+    @patch("app.routers.auth._get_user_by_username")
+    def test_login_database_error(self, mock_get_user, client: TestClient):
         """Test login when database error occurs."""
-        mock_auth.side_effect = Exception("Database connection failed")
+        mock_get_user.side_effect = Exception("Database connection failed")
 
         login_data = {"username": "testuser", "password": "password123"}
 

--- a/backend/tests/integration/auth/test_oidc_hybrid_auth.py
+++ b/backend/tests/integration/auth/test_oidc_hybrid_auth.py
@@ -6,19 +6,31 @@ Tests authentication dependency that accepts both local JWT and OIDC tokens.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import pytest_asyncio
 from fastapi import HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.dependencies import get_current_user
 from app.auth.oidc_validator import oidc_validator
 from app.models.models import User
 
 
+@pytest_asyncio.fixture
+async def async_session(test_async_db_session):
+    """Create an async session for testing."""
+    session = test_async_db_session()
+    try:
+        yield session
+    finally:
+        await session.close()
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_current_user_with_local_jwt(test_db_session: Session):
+async def test_get_current_user_with_local_jwt(test_db_session, async_session: AsyncSession):
     """Test get_current_user with valid local JWT token."""
-    # Create a test user
+    # Create a test user using sync session (to commit to DB)
     user = User(username="testuser", password_hash="hashed_password", auth_provider="local")
     test_db_session.add(user)
     test_db_session.commit()
@@ -33,8 +45,8 @@ async def test_get_current_user_with_local_jwt(test_db_session: Session):
     credentials = MagicMock()
     credentials.credentials = token
 
-    # Test
-    current_user = await get_current_user(credentials, test_db_session)
+    # Test with async session
+    current_user = await get_current_user(credentials, async_session)
 
     assert current_user.username == "testuser"
     assert current_user.auth_provider == "local"
@@ -42,9 +54,9 @@ async def test_get_current_user_with_local_jwt(test_db_session: Session):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_current_user_with_oidc_token_existing_user(test_db_session: Session):
+async def test_get_current_user_with_oidc_token_existing_user(test_db_session, async_session: AsyncSession):
     """Test get_current_user with valid OIDC token for existing user."""
-    # Create an OIDC user
+    # Create an OIDC user using sync session
     user = User(
         username="oidc_user",
         oidc_sub="authelia-sub-123",
@@ -78,7 +90,7 @@ async def test_get_current_user_with_oidc_token_existing_user(test_db_session: S
                     "email": "user@example.com",
                 }
 
-                current_user = await get_current_user(credentials, test_db_session)
+                current_user = await get_current_user(credentials, async_session)
 
                 assert current_user.username == "oidc_user"
                 assert current_user.auth_provider == "oidc"
@@ -87,7 +99,7 @@ async def test_get_current_user_with_oidc_token_existing_user(test_db_session: S
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_current_user_with_oidc_token_new_user_creation(test_db_session: Session):
+async def test_get_current_user_with_oidc_token_new_user_creation(test_db_session, async_session: AsyncSession):
     """Test auto-creation of user on first OIDC login."""
     # No user exists yet
     assert test_db_session.query(User).filter(User.oidc_sub == "authelia-sub-456").first() is None
@@ -114,7 +126,7 @@ async def test_get_current_user_with_oidc_token_new_user_creation(test_db_sessio
                     "email": "newuser@example.com",
                 }
 
-                current_user = await get_current_user(credentials, test_db_session)
+                current_user = await get_current_user(credentials, async_session)
 
                 assert current_user.username == "new_oidc_user"
                 assert current_user.auth_provider == "oidc"
@@ -122,15 +134,16 @@ async def test_get_current_user_with_oidc_token_new_user_creation(test_db_sessio
                 assert current_user.email == "newuser@example.com"
                 assert current_user.password_hash is None
 
-                # Verify user was created in database
-                db_user = test_db_session.query(User).filter(User.oidc_sub == "authelia-sub-456").first()
+                # Verify user was created in database using async session
+                result = await async_session.execute(select(User).filter(User.oidc_sub == "authelia-sub-456"))
+                db_user = result.scalar_one_or_none()
                 assert db_user is not None
                 assert db_user.username == "new_oidc_user"
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_current_user_both_auth_methods_fail(test_db_session: Session):
+async def test_get_current_user_both_auth_methods_fail(async_session: AsyncSession):
     """Test get_current_user fails when both local and OIDC validation fail."""
     # Mock credentials
     credentials = MagicMock()
@@ -142,14 +155,14 @@ async def test_get_current_user_both_auth_methods_fail(test_db_session: Session)
             mock_validate.side_effect = Exception("OIDC validation failed")
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials, test_db_session)
+                await get_current_user(credentials, async_session)
 
             assert exc_info.value.status_code == 401
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_current_user_oidc_user_email_fallback(test_db_session: Session):
+async def test_get_current_user_oidc_user_email_fallback(test_db_session, async_session: AsyncSession):
     """Test OIDC user creation uses email as username if preferred_username missing."""
     # Mock OIDC token with only email (no preferred_username)
     mock_claims = {
@@ -172,18 +185,19 @@ async def test_get_current_user_oidc_user_email_fallback(test_db_session: Sessio
                     "email": "emailonly@example.com",
                 }
 
-                current_user = await get_current_user(credentials, test_db_session)
+                current_user = await get_current_user(credentials, async_session)
 
                 assert current_user.username == "emailonly@example.com"
                 assert current_user.auth_provider == "oidc"
 
 
 @pytest.mark.integration
-def test_get_user_by_oidc_sub(test_db_session: Session):
-    """Test get_user_by_oidc_sub helper function."""
-    from app.auth.dependencies import get_user_by_oidc_sub
+@pytest.mark.asyncio
+async def test_get_user_by_oidc_sub(test_db_session, async_session: AsyncSession):
+    """Test _query_user_by_oidc_sub helper function."""
+    from app.auth.dependencies import _query_user_by_oidc_sub
 
-    # Create OIDC user
+    # Create OIDC user using sync session
     user = User(
         username="oidc_user",
         oidc_sub="authelia-sub-999",
@@ -194,11 +208,11 @@ def test_get_user_by_oidc_sub(test_db_session: Session):
     test_db_session.add(user)
     test_db_session.commit()
 
-    # Test finding user
-    found_user = get_user_by_oidc_sub(test_db_session, "authelia-sub-999")
+    # Test finding user with async query
+    found_user = await _query_user_by_oidc_sub(async_session, "authelia-sub-999")
     assert found_user is not None
     assert found_user.username == "oidc_user"
 
-    # Test user not found
-    not_found = get_user_by_oidc_sub(test_db_session, "non-existent-sub")
+    # Test non-existent user
+    not_found = await _query_user_by_oidc_sub(async_session, "non-existent")
     assert not_found is None

--- a/backend/tests/unit/routers/test_health_router.py
+++ b/backend/tests/unit/routers/test_health_router.py
@@ -8,7 +8,7 @@ from app.services.health_service import health_service
 
 
 class DummySession:
-    """Lightweight stand-in for a SQLAlchemy session."""
+    """Lightweight stand-in for a SQLAlchemy async session."""
 
 
 @pytest.mark.asyncio
@@ -17,7 +17,7 @@ async def test_health_check_returns_service_payload(monkeypatch):
 
     expected_payload = {"status": "healthy", "database": "connected"}
 
-    def fake_get_health_status(db):  # pragma: no cover - simple stub
+    async def fake_get_health_status(db):  # pragma: no cover - simple stub
         assert isinstance(db, DummySession)
         return expected_payload
 
@@ -32,7 +32,7 @@ async def test_health_check_returns_service_payload(monkeypatch):
 async def test_health_check_raises_http_exception_on_service_failure(monkeypatch):
     """The endpoint should convert service errors into HTTP 503 responses."""
 
-    def fake_get_health_status(_):  # pragma: no cover - simple stub
+    async def fake_get_health_status(_):  # pragma: no cover - simple stub
         raise RuntimeError("boom")
 
     monkeypatch.setattr(health_service, "get_health_status", fake_get_health_status)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,38 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -352,7 +384,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -363,7 +394,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -561,6 +591,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -608,6 +639,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bcrypt", specifier = "==3.2.0" },
     { name = "factory-boy", marker = "extra == 'dev'", specifier = "==3.3.0" },
     { name = "faker", marker = "extra == 'dev'", specifier = "==20.1.0" },


### PR DESCRIPTION
## Summary
- Migrate from synchronous SQLAlchemy sessions to async SQLAlchemy 2.0 with AsyncSession
- Fixes thread starvation caused by blocking DB calls in async routes

## Changes
- Add `asyncpg` dependency for PostgreSQL async driver
- Create `async_engine`, `AsyncSessionLocal`, and `get_async_db` async dependency
- Migrate all routers to async: notes, auth, settings, health
- Convert `db.query(...)` to `await db.execute(select(...))`
- Update auth/dependencies.py with async helper functions
- Update health_service to async methods
- Update test fixtures and unit tests for async support

## Test plan
- [x] All linting (`ruff check`) passes
- [x] All type checking (`mypy`) passes
- [x] Unit tests pass (199 passed)
- [ ] Integration tests (require Docker)
- [ ] Load test to verify improvement under concurrent load

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code) using remote-agent skill